### PR TITLE
Complete input approach overhaul

### DIFF
--- a/Project-I/project.cpp
+++ b/Project-I/project.cpp
@@ -58,7 +58,7 @@ int main()
                 cout << "Maximum days reached! Resetting data for a new cycle.\n";
                 day = 0;
             }
-            cout << "Enter data\n";
+            cout << "Enter Reports. (Hit ENTER to skip any empty fields!)\n";
             char opt;
             do
             {
@@ -78,17 +78,17 @@ int main()
 
                     for (int j = 0; j<nprod; ++j) {
                         string prodq;
+                    ReRead:
                         cout << products[j]<<": ";
-                        cin.clear();
                         getline(cin, prodq, '\n');
                         if(prodq.empty()) continue;
                         // TODO
-                        // what about character inputs? like letters?
+                        // what about invalid character inputs? like letters?
 
                         int qty = atoi(prodq.c_str());
-                        while(qty < 0) {
-                            cout << "\n\033[1;31mInvalid quantity!\033[0m\n" <<  "please enter a positive number: ";
-                            cin >> qty;
+                        if (qty < 0) {
+                            cout << "\n\033[1;31mInvalid quantity! Please enter a positive number!\033[0m\n\n";
+                            goto ReRead;
                         }
                         inventory[day][j][i] = qty;
                     }

--- a/Project-I/project.cpp
+++ b/Project-I/project.cpp
@@ -17,7 +17,7 @@ using namespace std;
 
 int main()
 {
-    const int nday = 30, nprod = 5, nwhouse = 4, maxrep = 5;
+    const int nday = 30, nprod = 5, nwhouse = 4;
     const float bon_rate = 0.05;
     const char jnt = '+', hln = '-', vln = '|'; // table drawing characters
     int inventory[nday][nprod][nwhouse] = {};
@@ -47,7 +47,7 @@ int main()
              << "1. Input Report" <<" (Day "<<(day%30)+1<<")"<< endl
              << "2. Generate Report" << endl
              << "3. Search" << endl
-             << "4. Display Information" << endl // New option to display information
+             << "4. Display Information" << endl 
              << "5. Exit" << endl;
         cin >> option;
         switch (option)
@@ -67,7 +67,7 @@ int main()
                 // somehow getline reads newline character from inputline
                 // the following clears it.
                 string throwaway;
-                getline(cin, throwaway, '\n'); // not ideal solution
+                getline(cin, throwaway, '\n');
                 for (int i = 0; i<nwhouse; ++i){
                     string ch;
                     cout<<"Warehouse "<<i+1<<"? (y/N): ";
@@ -82,12 +82,13 @@ int main()
                         cout << products[j]<<": ";
                         getline(cin, prodq, '\n');
                         if(prodq.empty()) continue;
-                        // TODO
-                        // what about invalid character inputs? like letters?
-                        while (isalpha(prodq[0])) {
+                        for (int i = 0; i < prodq.length(); i++){
+                        while (isalpha(prodq[i])) {
                             cout << "\n\033[1;31mInvalid input! Please enter a number!\033[0m\n" << std::endl; 
                             cout << products[j]<<": ";
                             getline(cin, prodq, '\n');
+                            break;
+                        }
                         }
                         int qty = atoi(prodq.c_str());
                         if (qty < 0 ) {
@@ -101,7 +102,7 @@ int main()
                 cout << "\nDone for the day! Continue? (Y/N): ";
                 cin >> opt;
                 cin.clear();
-                if (day == nday) { cout<<"All done!"; break; }// done this months reports
+                if (day == nday) { cout<<"All done!"; break; }// done this month's reports
             } while (tolower(opt) == 'y');
 
             break;
@@ -209,7 +210,9 @@ int main()
             int searchOption;
             cin >> searchOption;
             if (searchOption == 3) break; // Exit by choice
-            switch (searchOption) { case 1: { string productName; cout << "Enter product name to search: "; cin.clear(); cin >> productName;
+            switch (searchOption) { 
+                case 1: 
+                { string productName; cout << "Enter product name to search: "; cin.clear(); cin >> productName;
                 int prodIndex = -1;
                 for (int i = 0; i < nprod; ++i) {
                     if (!strncasecmp(products[i].c_str(), productName.c_str(), min(products[i].size(), productName.size())))

--- a/Project-I/project.cpp
+++ b/Project-I/project.cpp
@@ -84,9 +84,13 @@ int main()
                         if(prodq.empty()) continue;
                         // TODO
                         // what about invalid character inputs? like letters?
-
+                        while (isalpha(prodq[0])) {
+                            cout << "\n\033[1;31mInvalid input! Please enter a number!\033[0m\n" << std::endl; 
+                            cout << products[j]<<": ";
+                            getline(cin, prodq, '\n');
+                        }
                         int qty = atoi(prodq.c_str());
-                        if (qty < 0) {
+                        if (qty < 0 ) {
                             cout << "\n\033[1;31mInvalid quantity! Please enter a positive number!\033[0m\n\n";
                             goto ReRead;
                         }

--- a/Project-I/project.cpp
+++ b/Project-I/project.cpp
@@ -6,10 +6,12 @@
  *Byte Bandits, 2024.
  */
 
+#include <cctype>
 #include <iostream>
 #include <cstring>
 #include <algorithm>
 #include <iomanip>
+#include <string>
 
 using namespace std;
 
@@ -52,72 +54,52 @@ int main()
         {
         case 1:
         {
-            int count = 0;
+            if (day >= nday) {
+                cout << "Maximum days reached! Resetting data for a new cycle.\n";
+                day = 0;
+            }
+            cout << "Enter data\n";
             char opt;
             do
             {
-                if (day >= nday)
-                {
-                    cout << "Maximum days reached! Resetting data for a new cycle.\n";
-                    day = 0;
-                }
-                int whouse = 0;
-                string prod;
-                int qty = 0;
-
-                cout << "Enter data\n";
-                cin.clear();
                 cout << "Day " << day + 1 << endl;
-                cout << "Warehouse (1-4): ";
-                cin >> whouse;
-                cin.clear();
 
-                while(whouse < 1 || whouse > 4) {
-                cout << "\n\033[1;31mInvalid warehouse!\033[0m\n" <<  "please enter 1-4: ";
-                cin >> whouse;
-                }
-            goHere:
-                cout << "Product (";
-                for (auto prodct : products)
-                    cout << prodct << "/";
-                cout << "): ";
-                cin >> prod;
-                cin.clear();
-                int prindx = -1;
-                for (int i = 0; i < nprod; ++i)
-                {
-                    if (!strncasecmp(products[i].c_str(), prod.c_str(), min(products[i].size(), prod.size())))
-                    {
-                        prindx = i;
-                        break;
+                // somehow getline reads newline character from inputline
+                // the following clears it.
+                string throwaway;
+                getline(cin, throwaway, '\n'); // not ideal solution
+                for (int i = 0; i<nwhouse; ++i){
+                    string ch;
+                    cout<<"Warehouse "<<i+1<<"? (y/N): ";
+                    cin.clear();
+                    getline(cin, ch, '\n');
+
+                    if (ch.empty() || tolower(ch[0]) != 'y') continue;
+
+                    for (int j = 0; j<nprod; ++j) {
+                        string prodq;
+                        cout << products[j]<<": ";
+                        cin.clear();
+                        getline(cin, prodq, '\n');
+                        if(prodq.empty()) continue;
+                        // TODO
+                        // what about character inputs? like letters?
+
+                        int qty = atoi(prodq.c_str());
+                        while(qty < 0) {
+                            cout << "\n\033[1;31mInvalid quantity!\033[0m\n" <<  "please enter a positive number: ";
+                            cin >> qty;
+                        }
+                        inventory[day][j][i] = qty;
                     }
                 }
-
-                // not found
-                if (prindx == -1)
-                {
-                    cout << "\n\033[1;31mNo product found! Please choose valid product name!\033[0m\n";
-                    goto goHere;
-                }
-
-                cout << "Quantity: ";
-                cin >> qty;
-                cin.clear();
-                while(qty < 0) {
-                    cout << "\n\033[1;31mInvalid quantity!\033[0m\n" <<  "please enter a positive number: ";
-                    cin >> qty;
-                }
-
-                inventory[day][prindx][whouse - 1] = qty;
-                ++count;
-                if (count == maxrep)
-                    break; // done with todays reports
-                cout << "Done with today's report? (Y/N): ";
+                ++day;
+                cout << "\nDone for the day! Continue? (Y/N): ";
                 cin >> opt;
                 cin.clear();
-            } while ((opt != 'y' && opt != 'Y'));
+                if (day == nday) { cout<<"All done!"; break; }// done this months reports
+            } while (tolower(opt) == 'y');
 
-            ++day;
             break;
         }
         case 2:


### PR DESCRIPTION
Previously it was assumed that only five inputs were allowed per day. But after revisiting the original requirement, it asks for 0-5 reports from every warehouse making it 0-20 reports a day.

This pr fixes that with complete remaking of input approach.
- Takes up to 20 reports a day
- Allows skipping empty entries just by hitting Enter
- Allows entering more than one days' report continuously

Now is input is a lot faster and straight-forward.
